### PR TITLE
Update Podspec to specify swift version support

### DIFF
--- a/Re-Lax.podspec
+++ b/Re-Lax.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.platform = ['tvos']
   spec.tvos.deployment_target = '9.0'
+  spec.swift_version    = '4.1'
 end


### PR DESCRIPTION
This fixes the problem where a new swift version that has breaking changes prevents  a host project from building against the latest swift version.